### PR TITLE
Enable execution of binaries after code signing for ARM64 (Apple Silicon)

### DIFF
--- a/Formula/mec.rb
+++ b/Formula/mec.rb
@@ -5,9 +5,13 @@ class Mec < Formula
 
   # Multi-platform standalone binaries (no Node.js required)
   on_macos do
-    # Use x64 for better compatibility - Apple Silicon runs x64 via Rosetta
-    url "https://github.com/medallia/mec-cli/releases/download/v1.0.0/mec-macos-x64.tgz"
-    sha256 "a8ad0e26ff6ed9d182afbeba7d6bed83fa0c4732b56f886723e2985796e65dd2"
+    if Hardware::CPU.arm?
+      url "https://github.com/medallia/mec-cli/releases/download/v1.0.0/mec-macos-arm64.tgz"
+      sha256 "f1e80befebe4fb673c6a9d8fd81e0a972f91e6e9676298534e58359d6e15d262"
+    else
+      url "https://github.com/medallia/mec-cli/releases/download/v1.0.0/mec-macos-x64.tgz"
+      sha256 "a8ad0e26ff6ed9d182afbeba7d6bed83fa0c4732b56f886723e2985796e65dd2"
+    end
   end
   
   on_linux do
@@ -29,9 +33,12 @@ class Mec < Formula
 
   def install
     # Homebrew automatically extracts .tgz files
-    # For macOS, we always use x64; for Linux, detect the architecture
     if OS.mac?
-      binary_name = "mec-macos-x64"
+      if Hardware::CPU.arm?
+        binary_name = "mec-macos-arm64"
+      else
+        binary_name = "mec-macos-x64"
+      end
     elsif Hardware::CPU.arm?
       binary_name = "mec-linux-arm64"
     else


### PR DESCRIPTION
## Code Signing & Distributing ARM64 Binary

### For Development/Testing (Ad-hoc Signing):
Works locally; users will see security warnings.
```sh
# Sign:
codesign --force --sign - mec-macos-arm64
```

### Production (Apple Developer Program, Recommended)

Requires Developer ID certificate.

Sign, notarize, and verify binary:
```sh
# Sign:
codesign --force --sign "Developer ID Application: Your Company Name" \
         --options runtime \
         --timestamp \
         mec-macos-arm64

# Verify signature:
codesign --verify --verbose mec-macos-arm64

# Full Gatekeeper check:
spctl -a -t exec -vv mec-macos-arm64
```